### PR TITLE
Change type from `FutureOr` to `Future`

### DIFF
--- a/snippets/async_notifier.code-snippets
+++ b/snippets/async_notifier.code-snippets
@@ -6,7 +6,7 @@
 		"body": [
 			"class $1Notifier extends AsyncNotifier<$2> {",
 			"\t@override",
-			"\tFutureOr<$2> build() {",
+			"\tFuture<$2> build() async {",
 			"\t\treturn $3;",
 			"\t}",
 			"}"
@@ -19,7 +19,7 @@
 		"body": [
 			"class $1Notifier extends FamilyAsyncNotifier<$2, $3> {",
 			"\t@override",
-			"\tFutureOr<$2> build($3 arg) {",
+			"\tFuture<$2> build($3 arg) async {",
 			"\t\treturn $4;",
 			"\t}",
 			"}"

--- a/snippets/code_generator.code-snippets
+++ b/snippets/code_generator.code-snippets
@@ -35,7 +35,7 @@
 		"description": "Creates a FutureProvider",
 		"body": [
 			"@riverpod",
-			"FutureOr<$1> $2(${2/(.*)/${1:/capitalize}/}Ref ref) {",
+			"Future<$1> $2(${2/(.*)/${1:/capitalize}/}Ref ref) async {",
 			"\treturn $3;",
 			"}",
 		]
@@ -46,7 +46,7 @@
 		"description": "Creates a keep alive FutureProvider",
 		"body": [
 			"@Riverpod(keepAlive: true)",
-			"FutureOr<$1> $2(${2/(.*)/${1:/capitalize}/}Ref ref) {",
+			"Future<$1> $2(${2/(.*)/${1:/capitalize}/}Ref ref) async {",
 			"\treturn $3;",
 			"}",
 		]
@@ -109,7 +109,7 @@
 			"@riverpod",
 			"class $1 extends _$$1 {",
 			"\t@override",
-			"\tFutureOr<$2> build() {",
+			"\tFuture<$2> build() async {",
 			"\t\treturn $3;",
 			"\t}",
 			"}",
@@ -123,7 +123,7 @@
 			"@Riverpod(keepAlive: true)",
 			"class $1 extends _$$1 {",
 			"\t@override",
-			"\tFutureOr<$2> build() {",
+			"\tFuture<$2> build() async {",
 			"\t\treturn $3;",
 			"\t}",
 			"}",


### PR DESCRIPTION
# Description

This pull request updates the generated code type in the snippets from FutureOr to Future to align with the changes in the official Riverpod documentation.

# Motivation

The official Riverpod documentation has been updated to use Future instead of FutureOr for asynchronous providers. To maintain consistency and avoid confusion, it is important to update the snippets in this extension to match the current best practices recommended by the Riverpod team.

# Changes

Modified the snippets to generate code with Future return type instead of FutureOr.
