### PR TITLE
3.0 snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the **flutter-riverpod-snippets** extension will be docum
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### [2.0.0]
+- Support for `Riverpod` **v3.0**
+- simplified most snippets
+- improved some prefix for correctness, consistency and simplicity
+- improved snippet titles and descriptions
+
 ### [1.2.2]
 
 ### Add

--- a/README.md
+++ b/README.md
@@ -7,53 +7,62 @@ snippets such as `provider`.
 
 ## Snippets
 
-| Shortcut                       | Description                                                                 |
-| ------------------------------ | --------------------------------------------------------------------------- |
-| `consumer`                     | Creates the Consumer widget                                                 |
-| `stlessConsumer`               | Creates a ConsumerStateless widget                                          |
-| `stfulConsumer`                | Creates a ConsumerStateful widget                                           |
-| `stlessHookConsumer`           | Creates a Stateless HookConsumer widget                                     |
-| `stfulHookConsumer`            | Creates a Stateful HookConsumer widget                                      |
-| `provider`                     | Creates a simple riverpod provider                                          |
-| `providerFamily`               | Creates a provider with the family modifier                                 |
-| `futureProvider`               | Creates a FutureProvider                                                    |
-| `futureProviderFamily`         | Creates a FutureProvider with the family modifier                           |
-| `streamProvider`               | Creates a StreamProvider                                                    |
-| `streamProviderFamily`         | Creates a StreamProvider with the family modifier                           |
-| `changeNotifierProvider`       | Creates a ChangeNotifierProvider                                            |
-| `changeNotifierProviderFamily` | Creates a ChangeNotifierProvider with the family modifier                   |
-| `stateProvider`                | Creates a StateProvider                                                     |
-| `stateProviderFamily`          | Creates a StateProvider with the family modifier                            |
-| `stateProviderFamily`          | Creates a StateProvider with the family modifier                            |
-| `stateNotifierProvider`        | Creates a StateNotifier provider                                            |
-| `stateNotifierProviderFamily`  | Creates a StateNotifierProvider with the family modifier                    |
-| `stateNotifier`                | Creates a class that extends StateNotifier and allows you to edit the types |
-| `asyncNotifierProvider`        | Create an AsyncNotifierProvider                                             |
-| `asyncNotifierProviderFamily`  | Create an AsyncNotifierProvider with Family Modifier                        |
-| `asyncNotifier`                | Create an AsyncNotifier class                                               |
-| `asyncNotifierFamily`          | Create an AsyncNotifier with Family Parameter                               |
-| `notifierProvider`             | Create a NotifierProvider                                                   |
-| `notifierProviderFamily`       | Create a NotifierProvider with Family Modifier                              |
-| `notifier`                     | Create a Notifier class                                                     |
-| `notifierFamily`               | Create a Notifier with Family Parameter                                     |
-| `streamNotifierProvider`        | Create an StreamNotifierProvider                                           |
-| `streamNotifierProviderFamily`  | Create an StreamNotifierProvider with Family Modifier                      |
-| `streamNotifier`                | Create an StreamNotifier class                                             |
-| `streamNotifierFamily`          | Create an StreamNotifier with Family Parameter                             |
-| `listen`                       | Creates a Provider Listenable                                               |
-| `riverpod`                     | Creates a simple Provider                                                   |
-| `riverpodKeepAlive`            | Creates a simple keep alive Provider                                        |
-| `riverpodFuture`               | Creates a FutureProvider                                                    |
-| `riverpodFutureKeepAlive`      | Creates a keep alive FutureProvider                                         |
-| `riverpodStream`               | Creates a StreamProvider                                                    |
-| `riverpodStreamKeepAlive`      | Creates a keep alive StreamProvider                                         |
-| `riverpodClass`                | Creates a class Provider                                                    |
-| `riverpodClassKeepAlive`       | Creates a keep alive class Provider                                         |
-| `riverpodAsyncClass`           | Creates an async class Provider                                             |
-| `riverpodAsyncClassKeepAlive`  | Creates a keep alive async class Provider                                   |
-| `riverpodStreamClass`           | Creates an stream class Provider                                           |
-| `riverpodStreamClassKeepAlive`  | Creates a keep alive stream class Provider                                 |
-| `riverpodPart`                 | Create a part statement for Riverpod                                        |
+| Shortcut                             | Description                                                                 |
+| ------------------------------------ | --------------------------------------------------------------------------- |
+| `consumer`                           | Creates the Consumer widget                                                 |
+| `statelessConsumerWidget`            | Creates a ConsumerWidget                                                    |
+| `statefulConsumerWidget`             | Creates a ConsumerStatefulWidget                                            |
+| `statelessHookConsumerWidget`        | Creates a HookConsumerWidget                                                |
+| `statefulHookConsumerWidget`         | Creates a StatefulHookConsumerWidget                                        |
+| `provider`                           | Creates an autodispose Provider                                             |
+| `providerKeepAlive`                  | Creates a non-autodispose Provider                                          |
+| `providerFamily`                     | Creates an autodispose family provider                                      |
+| `futureProvider`                     | Creates an autodispose FutureProvider                                       |
+| `futureProviderKeepAlive`            | Creates a non-autodispose FutureProvider                                    |
+| `futureProviderFamily`               | Creates an autodispose family FutureProvider                                |
+| `streamProvider`                     | Creates an autodispose StreamProvider                                       |
+| `streamProviderKeepAlive`            | Creates a non-autodispose StreamProvider                                    |
+| `streamProviderFamily`               | Creates an autodispose family StreamProvider                                |
+| `changeNotifier`                     | Creates a ChangeNotifierProvider                                            |
+| `changeNotifierProvider`             | Creates an autodispose ChangeNotifierProvider                               |
+| `changeNotifierProviderKeepAlive`    | Creates a non-autodispose ChangeNotifierProvider                            |
+| `changeNotifierProviderFamily`       | Creates an autodispose family ChangeNotifierProvider                        |
+| `stateProvider`                      | Creates an autodispose StateProvider (legacy)                               |
+| `stateProviderKeepAlive`             | Creates a non-autodispose StateProvider (legacy)                            |
+| `stateProviderFamily`                | Creates an autodispose family StateProvider (legacy)                        |
+| `stateNotifierProvider`              | Creates an autodispose StateNotifierProvider (legacy)                       |
+| `stateNotifierProviderKeepAlive`     | Creates a non-autodispose StateNotifierProvider (legacy)                    |
+| `stateNotifierProviderFamily`        | Creates an autodispose family StateNotifierProvider (legacy)                |
+| `stateNotifier`                      | Creates a StateNotifier (legacy)                                            |
+| `stateNotifierFamily`                | Creates a parametrized StateNotifier (legacy)                               |
+| `asyncNotifierProvider`              | Creates an autodispose AsyncNotifierProvider                                |
+| `asyncNotifierProviderFamily`        | Creates an autodispose family AsyncNotifierProvider                         |
+| `asyncNotifier`                      | Creates an AsyncNotifier                                                    |
+| `asyncNotifierFamily`                | Creates a parametrized AsyncNotifier                                        |
+| `notifierProvider`                   | Creates an autodispose NotifierProvider                                     |
+| `notifierProviderKeepAlive`          | Creates a non-autodispose NotifierProvider                                  |
+| `notifierProviderFamily`             | Creates an autodispose family NotifierProvider                              |
+| `notifier`                           | Creates a Notifier                                                          |
+| `notifierFamily`                     | Creates a parametrized Notifier                                             |
+| `streamNotifierProvider`             | Creates an autodispose StreamNotifierProvider                               |
+| `streamNotifierProviderKeepAlive`    | Creates a non-autodispose StreamNotifierProvider                            |
+| `streamNotifierProviderFamily`       | Creates an autodispose family StreamNotifierProvider                        |
+| `streamNotifier`                     | Creates a StreamNotifier                                                    |
+| `streamNotifierFamily`               | Creates a parametrized StreamNotifier                                       |
+| `listen`                             | Listens to a provider                                                       |
+| `riverpod`                           | Creates an autodispose Provider (codegen)                                   |
+| `riverpodKeepAlive`                  | Creates a non-autodipose Provider (codegen)                                 |
+| `riverpodFuture`                     | Creates an autodispose FutureProvider (codegen)                             |
+| `riverpodFutureKeepAlive`            | Creates a non-autodispose FutureProvider (codegen)                          |
+| `riverpodStream`                     | Creates an autodispose StreamProvider (codegen)                             |
+| `riverpodStreamKeepAlive`            | Creates a non-autodispose StreamProvider (codegen)                          |
+| `riverpodClass`                      | Creates an autodispose Notifier/NotifierProvider (codegen)                  |
+| `riverpodClassKeepAlive`             | Creates a non-autodispose Notifier/NotifierProvider (codegen)               |
+| `riverpodAsyncClass`                 | Creates an autodispose AsyncNotifier/AsyncNotifierProvider (codegen)        |
+| `riverpodAsyncClassKeepAlive`        | Creates a non-autodispose AsyncNotifier/AsyncNotifierProvide (codegen)      |
+| `riverpodStreamClass`                | Creates an autodispose StreamNotifier/StreamNotifierProvider (codegen)      |
+| `riverpodStreamClassKeepAlive`       | Creates a non-autodispose StreamNotifier/StreamNotifierProvider (codegen)   |
+| `riverpodPart`                       | Creates a part statement for Riverpod (codegen)                             |
 
 ## Contributing
 Feel free to open PRs for small issues such as typos. For large issues or features, please open an issue first.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Flutter Riverpod Snippets",
   "description": "Quick and easy Flutter Riverpod snippets",
   "icon": "logo.jpg",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "publisher": "robert-brunhage",
   "homepage": "https://github.com/RobertBrunhage/flutter-riverpod-snippets",
   "repository": {

--- a/snippets/async_notifier.code-snippets
+++ b/snippets/async_notifier.code-snippets
@@ -15,7 +15,7 @@
 	"Riverpod: Family AsyncNotifier class": {
 		"scope": "dart",
 		"prefix": "asyncNotifierFamily",
-		"description": "Create an AsyncNotifier with Family Parameter",
+		"description": "Create a parametrized AsyncNotifier",
 		"body": [
 			"class $1Notifier extends AsyncNotifier<$2> {",
 			"\t$1Notifier(this.$4);",

--- a/snippets/async_notifier.code-snippets
+++ b/snippets/async_notifier.code-snippets
@@ -7,7 +7,7 @@
 			"class $1Notifier extends AsyncNotifier<$2> {",
 			"\t@override",
 			"\tFutureOr<$2> build() {",
-			"\t\treturn $3;",
+			"\t\t$3",
 			"\t}",
 			"}"
 		]
@@ -22,7 +22,7 @@
 			"\tfinal $3 $4;",
 			"\t@override",
 			"\tFutureOr<$2> build() {",
-			"\t\treturn $5;",
+			"\t\t$5",
 			"\t}",
 			"}"
 		]

--- a/snippets/async_notifier.code-snippets
+++ b/snippets/async_notifier.code-snippets
@@ -1,6 +1,6 @@
 {
-    "Riverpod: AsyncNotifier class": {
-        "scope": "dart",
+	"Riverpod: AsyncNotifier class": {
+		"scope": "dart",
 		"prefix": "asyncNotifier",
 		"description": "Create an AsyncNotifier class",
 		"body": [
@@ -13,14 +13,16 @@
 		]
 	},
 	"Riverpod: Family AsyncNotifier class": {
-        "scope": "dart",
+		"scope": "dart",
 		"prefix": "asyncNotifierFamily",
 		"description": "Create an AsyncNotifier with Family Parameter",
 		"body": [
-			"class $1Notifier extends FamilyAsyncNotifier<$2, $3> {",
+			"class $1Notifier extends AsyncNotifier<$2> {",
+			"\t$1Notifier(this.$4);",
+			"\tfinal $3 $4;",
 			"\t@override",
-			"\tFutureOr<$2> build($3 arg) {",
-			"\t\treturn $4;",
+			"\tFutureOr<$2> build() {",
+			"\t\treturn $5;",
 			"\t}",
 			"}"
 		]

--- a/snippets/async_notifier.code-snippets
+++ b/snippets/async_notifier.code-snippets
@@ -1,8 +1,8 @@
 {
-	"Riverpod: AsyncNotifier class": {
+	"Riverpod: AsyncNotifier": {
 		"scope": "dart",
 		"prefix": "asyncNotifier",
-		"description": "Create an AsyncNotifier class",
+		"description": "Creates an AsyncNotifier",
 		"body": [
 			"class $1Notifier extends AsyncNotifier<$2> {",
 			"\t@override",
@@ -12,10 +12,10 @@
 			"}"
 		]
 	},
-	"Riverpod: Family AsyncNotifier class": {
+	"Riverpod: Family AsyncNotifier": {
 		"scope": "dart",
 		"prefix": "asyncNotifierFamily",
-		"description": "Create a parametrized AsyncNotifier",
+		"description": "Creates a parametrized AsyncNotifier",
 		"body": [
 			"class $1Notifier extends AsyncNotifier<$2> {",
 			"\t$1Notifier(this.$4);",

--- a/snippets/async_notifier_provider.code-snippets
+++ b/snippets/async_notifier_provider.code-snippets
@@ -1,5 +1,5 @@
 {
-	"Riverpod: AsyncNotifier Provider with .autoDispose": {
+	"Riverpod: AsyncNotifier Provider": {
 		"scope": "dart",
 		"prefix": "asyncNotifierProvider",
 		"description": "Create an autodispose AsyncNotifierProvider",
@@ -7,15 +7,15 @@
 			"final $1Provider = AsyncNotifierProvider.autoDispose<$2, $3>($2.new);",
 		]
 	},
-	"Riverpod: AsyncNotifier Provider": {
+	"Riverpod: Keep Alive AsyncNotifier Provider": {
 		"scope": "dart",
-		"prefix": "alwaysAliveAsyncNotifierProvider",
+		"prefix": "asyncNotifierProviderKeepAlive",
 		"description": "Create a non-autodispose AsyncNotifierProvider",
 		"body": [
 			"final $1Provider = AsyncNotifierProvider<$2, $3>($2.new);",
 		]
 	},
-	"Riverpod: AsyncNotifier Provider with .family and .autoDispose": {
+	"Riverpod: .family AsyncNotifier Provider": {
 		"scope": "dart",
 		"prefix": "asyncNotifierProviderFamily",
 		"description": "Create an autodispose family AsyncNotifierProvider",

--- a/snippets/async_notifier_provider.code-snippets
+++ b/snippets/async_notifier_provider.code-snippets
@@ -2,7 +2,7 @@
 	"Riverpod: AsyncNotifierProvider": {
 		"scope": "dart",
 		"prefix": "asyncNotifierProvider",
-		"description": "Create an autodispose AsyncNotifierProvider",
+		"description": "Creates an autodispose AsyncNotifierProvider",
 		"body": [
 			"final $1Provider = AsyncNotifierProvider.autoDispose<$2, $3>($2.new);",
 		]
@@ -10,7 +10,7 @@
 	"Riverpod: Keep Alive AsyncNotifierProvider": {
 		"scope": "dart",
 		"prefix": "asyncNotifierProviderKeepAlive",
-		"description": "Create a non-autodispose AsyncNotifierProvider",
+		"description": "Creates a non-autodispose AsyncNotifierProvider",
 		"body": [
 			"final $1Provider = AsyncNotifierProvider<$2, $3>($2.new);",
 		]
@@ -18,7 +18,7 @@
 	"Riverpod: .family AsyncNotifierProvider": {
 		"scope": "dart",
 		"prefix": "asyncNotifierProviderFamily",
-		"description": "Create an autodispose family AsyncNotifierProvider",
+		"description": "Creates an autodispose family AsyncNotifierProvider",
 		"body": [
 			"final $1Provider = AsyncNotifierProvider.autoDispose.family<$2, $3, $4>($2.new);",
 		]

--- a/snippets/async_notifier_provider.code-snippets
+++ b/snippets/async_notifier_provider.code-snippets
@@ -1,5 +1,5 @@
 {
-	"Riverpod: AsyncNotifier Provider": {
+	"Riverpod: AsyncNotifierProvider": {
 		"scope": "dart",
 		"prefix": "asyncNotifierProvider",
 		"description": "Create an autodispose AsyncNotifierProvider",
@@ -7,7 +7,7 @@
 			"final $1Provider = AsyncNotifierProvider.autoDispose<$2, $3>($2.new);",
 		]
 	},
-	"Riverpod: Keep Alive AsyncNotifier Provider": {
+	"Riverpod: Keep Alive AsyncNotifierProvider": {
 		"scope": "dart",
 		"prefix": "asyncNotifierProviderKeepAlive",
 		"description": "Create a non-autodispose AsyncNotifierProvider",
@@ -15,12 +15,12 @@
 			"final $1Provider = AsyncNotifierProvider<$2, $3>($2.new);",
 		]
 	},
-	"Riverpod: .family AsyncNotifier Provider": {
+	"Riverpod: .family AsyncNotifierProvider": {
 		"scope": "dart",
 		"prefix": "asyncNotifierProviderFamily",
 		"description": "Create an autodispose family AsyncNotifierProvider",
 		"body": [
-			"final $1Provider = AsyncNotifierProvider.family.autoDispose<$2, $3, $4>($2.new);",
+			"final $1Provider = AsyncNotifierProvider.autoDispose.family<$2, $3, $4>($2.new);",
 		]
 	},
 }

--- a/snippets/async_notifier_provider.code-snippets
+++ b/snippets/async_notifier_provider.code-snippets
@@ -1,18 +1,26 @@
 {
-    "Riverpod: AsyncNotifier Provider": {
-        "scope": "dart",
+	"Riverpod: AsyncNotifier Provider with .autoDispose": {
+		"scope": "dart",
 		"prefix": "asyncNotifierProvider",
-		"description": "Create an AsyncNotifierProvider",
+		"description": "Create an autodispose AsyncNotifierProvider",
+		"body": [
+			"final $1Provider = AsyncNotifierProvider.autoDispose<$2, $3>($2.new);",
+		]
+	},
+	"Riverpod: AsyncNotifier Provider": {
+		"scope": "dart",
+		"prefix": "alwaysAliveAsyncNotifierProvider",
+		"description": "Create a non-autodispose AsyncNotifierProvider",
 		"body": [
 			"final $1Provider = AsyncNotifierProvider<$2, $3>($2.new);",
 		]
 	},
-	"Riverpod: AsyncNotifier Provider with Family": {
-        "scope": "dart",
+	"Riverpod: AsyncNotifier Provider with .family and .autoDispose": {
+		"scope": "dart",
 		"prefix": "asyncNotifierProviderFamily",
-		"description": "Create an AsyncNotifierProvider with Family Modifier",
+		"description": "Create an autodispose family AsyncNotifierProvider",
 		"body": [
-			"final $1Provider = AsyncNotifierProviderFamily<$2, $3, $4>($2.new);",
+			"final $1Provider = AsyncNotifierProvider.family.autoDispose<$2, $3, $4>($2.new);",
 		]
 	},
 }

--- a/snippets/change_notifier.code-snippets
+++ b/snippets/change_notifier.code-snippets
@@ -2,7 +2,7 @@
     "Riverpod (legacy): Change Notifier": {
         "scope": "dart",
         "prefix": "changeNotifier",
-        "description": "Create a ChangeNotifier",
+        "description": "Creates a ChangeNotifier",
         "body": [
             "class $1Notifier extends ChangeNotifier {",
             "\t$2",

--- a/snippets/change_notifier.code-snippets
+++ b/snippets/change_notifier.code-snippets
@@ -1,8 +1,8 @@
 {
-    "State Notifier": {
+    "Legacy: Change Notifier": {
         "scope": "dart",
         "prefix": "changeNotifier",
-        "description": "Create a ChangeNotifier with Editable Parameter",
+        "description": "Create a ChangeNotifier",
         "body": [
             "class $1Notifier extends ChangeNotifier {",
             "\t$2",

--- a/snippets/change_notifier.code-snippets
+++ b/snippets/change_notifier.code-snippets
@@ -1,5 +1,5 @@
 {
-    "Legacy: Change Notifier": {
+    "Riverpod (legacy): Change Notifier": {
         "scope": "dart",
         "prefix": "changeNotifier",
         "description": "Create a ChangeNotifier",

--- a/snippets/change_notifier_provider.code-snippets
+++ b/snippets/change_notifier_provider.code-snippets
@@ -1,5 +1,5 @@
 {
-  "Legacy: ChangeNotifier Provider": {
+  "Riverpod (legacy): ChangeNotifier Provider": {
     "scope": "dart",
     "prefix": "changeNotifierProvider",
     "description": "Create an autodispose ChangeNotifierProvider",
@@ -9,7 +9,7 @@
       "});"
     ]
   },
-  "Legacy: Keep Alive ChangeNotifier Provider": {
+  "Riverpod (legacy): Keep Alive ChangeNotifier Provider": {
     "scope": "dart",
     "prefix": "changeNotifierProviderKeepAlive",
     "description": "Create a non-autodispose ChangeNotifierProvider",
@@ -19,7 +19,7 @@
       "});"
     ]
   },
-  "Legacy: .family ChangeNotifier Provider": {
+  "Riverpod (legacy): .family ChangeNotifier Provider": {
     "scope": "dart",
     "prefix": "changeNotifierProviderFamily",
     "description": "Create an autodispose family ChangeNotifierProvider",

--- a/snippets/change_notifier_provider.code-snippets
+++ b/snippets/change_notifier_provider.code-snippets
@@ -9,9 +9,9 @@
       "});"
     ]
   },
-  "Legacy: Always-Alive ChangeNotifier Provider": {
+  "Legacy: Keep Alive ChangeNotifier Provider": {
     "scope": "dart",
-    "prefix": "alwaysAliveChangeNotifierProvider",
+    "prefix": "changeNotifierProviderKeepAlive",
     "description": "Create a non-autodispose ChangeNotifierProvider",
     "body": [
       "final $1Provider = ChangeNotifierProvider<$2>((ref) {",

--- a/snippets/change_notifier_provider.code-snippets
+++ b/snippets/change_notifier_provider.code-snippets
@@ -2,7 +2,7 @@
   "Riverpod (legacy): ChangeNotifier Provider": {
     "scope": "dart",
     "prefix": "changeNotifierProvider",
-    "description": "Create an autodispose ChangeNotifierProvider",
+    "description": "Creates an autodispose ChangeNotifierProvider",
     "body": [
       "final $1Provider = ChangeNotifierProvider.autoDispose<$2>((ref) {",
       "\treturn $2();",
@@ -12,7 +12,7 @@
   "Riverpod (legacy): Keep Alive ChangeNotifier Provider": {
     "scope": "dart",
     "prefix": "changeNotifierProviderKeepAlive",
-    "description": "Create a non-autodispose ChangeNotifierProvider",
+    "description": "Creates a non-autodispose ChangeNotifierProvider",
     "body": [
       "final $1Provider = ChangeNotifierProvider<$2>((ref) {",
       "\treturn $2();",
@@ -22,7 +22,7 @@
   "Riverpod (legacy): .family ChangeNotifier Provider": {
     "scope": "dart",
     "prefix": "changeNotifierProviderFamily",
-    "description": "Create an autodispose family ChangeNotifierProvider",
+    "description": "Creates an autodispose family ChangeNotifierProvider",
     "body": [
       "final $1Provider = ChangeNotifierProvider.autoDispose.family<$2, $3>((ref, $4) {",
       "\treturn $5($4);",

--- a/snippets/change_notifier_provider.code-snippets
+++ b/snippets/change_notifier_provider.code-snippets
@@ -1,21 +1,31 @@
 {
-  "Change Notifier Provider": {
+  "Legacy: ChangeNotifier Provider": {
     "scope": "dart",
     "prefix": "changeNotifierProvider",
-    "description": "Create a ChangeNotifierProvider",
+    "description": "Create an autodispose ChangeNotifierProvider",
     "body": [
-      "final $1Provider = ChangeNotifierProvider<$2>((ref) {",
-      "\treturn $3;",
+      "final $1Provider = ChangeNotifierProvider.autoDispose<$2>((ref) {",
+      "\treturn $2();",
       "});"
     ]
   },
-  "Change Notifier Provider with Family": {
+  "Legacy: Always-Alive ChangeNotifier Provider": {
+    "scope": "dart",
+    "prefix": "alwaysAliveChangeNotifierProvider",
+    "description": "Create a non-autodispose ChangeNotifierProvider",
+    "body": [
+      "final $1Provider = ChangeNotifierProvider<$2>((ref) {",
+      "\treturn $2();",
+      "});"
+    ]
+  },
+  "Legacy: .family ChangeNotifier Provider": {
     "scope": "dart",
     "prefix": "changeNotifierProviderFamily",
-    "description": "Create a ChangeNotifierProvider with Family modifier",
+    "description": "Create an autodispose family ChangeNotifierProvider",
     "body": [
-      "final $1Provider = ChangeNotifierProvider.family<$2, $3>((ref, $4) {",
-      "\treturn $5;",
+      "final $1Provider = ChangeNotifierProvider.autoDispose.family<$2, $3>((ref, $4) {",
+      "\treturn $5($4);",
       "});"
     ]
   }

--- a/snippets/code_generator.code-snippets
+++ b/snippets/code_generator.code-snippets
@@ -1,158 +1,158 @@
 {
-	"Riverpod: part statement": {
+	"Riverpod codegen: part statement": {
 		"scope": "dart",
 		"prefix": "riverpodPart",
-		"description": "Create a part statement for Riverpod",
+		"description": "Create a part statement for Riverpod (codegen)",
 		"body": [
 			"part '${TM_FILENAME_BASE}.g.dart';",
 		]
 	},
-        "Riverpod: simple instance": {
-                "scope": "dart",
+	"Riverpod codegen: Provider": {
+		"scope": "dart",
 		"prefix": "riverpod",
-		"description": "Creates a simple Provider",
+		"description": "Create a Provider (codegen)",
 		"body": [
 			"@riverpod",
-			"$1 $2(${2/(.*)/${1:/capitalize}/}Ref ref) {",
-			"\treturn $3;",
+			"$1 $2(Ref ref) {",
+			"\t$3;",
 			"}",
 		]
 	},
-	"Riverpod: simple keep alive instance": {
-        "scope": "dart",
+	"Riverpod codegen: Keep Alive Provider": {
+		"scope": "dart",
 		"prefix": "riverpodKeepAlive",
-		"description": "Creates a simple keep alive Provider",
+		"description": "Create a non-autodispose Provider (codegen)",
 		"body": [
 			"@Riverpod(keepAlive: true)",
-			"$1 $2(${2/(.*)/${1:/capitalize}/}Ref ref) {",
-			"\treturn $3;",
+			"$1 $2(Ref ref) {",
+			"\t$3;",
 			"}",
 		]
 	},
-	"Riverpod: future instance": {
-        "scope": "dart",
+	"Riverpod codegen: FutureProvider": {
+		"scope": "dart",
 		"prefix": "riverpodFuture",
-		"description": "Creates a FutureProvider",
+		"description": "Create a FutureProvider (codegen)",
 		"body": [
 			"@riverpod",
-			"FutureOr<$1> $2(${2/(.*)/${1:/capitalize}/}Ref ref) {",
-			"\treturn $3;",
+			"FutureOr<$1> $2(Ref ref) {",
+			"\t$3;",
 			"}",
 		]
 	},
-	"Riverpod: keep alive future instance": {
-        "scope": "dart",
+	"Riverpod codegen: Keep Alive FutureProvider": {
+		"scope": "dart",
 		"prefix": "riverpodFutureKeepAlive",
-		"description": "Creates a keep alive FutureProvider",
+		"description": "Create a Keep Alive FutureProvider (codegen)",
 		"body": [
 			"@Riverpod(keepAlive: true)",
-			"FutureOr<$1> $2(${2/(.*)/${1:/capitalize}/}Ref ref) {",
-			"\treturn $3;",
+			"FutureOr<$1> $2(Ref ref) {",
+			"\t$3;",
 			"}",
 		]
 	},
-	"Riverpod: stream instance": {
-        "scope": "dart",
+	"Riverpod codegen: StreamProvider": {
+		"scope": "dart",
 		"prefix": "riverpodStream",
-		"description": "Creates a StreamProvider",
+		"description": "Create a StreamProvider (codegen)",
 		"body": [
 			"@riverpod",
-			"Stream<$1> $2(${2/(.*)/${1:/capitalize}/}Ref ref) {",
-			"\treturn $3;",
+			"Stream<$1> $2(Ref ref) {",
+			"\t$3;",
 			"}",
 		]
 	},
-	"Riverpod: keep alive stream instance": {
-        "scope": "dart",
+	"Riverpod codegen: Keep Alive StreamProvider": {
+		"scope": "dart",
 		"prefix": "riverpodStreamKeepAlive",
-		"description": "Creates a keep alive StreamProvider",
+		"description": "Create a Keep Alive StreamProvider (codegen)",
 		"body": [
 			"@Riverpod(keepAlive: true)",
-			"Stream<$1> $2(${2/(.*)/${1:/capitalize}/}Ref ref) {",
-			"\treturn $3;",
+			"Stream<$1> $2(Ref ref) {",
+			"\t$3;",
 			"}",
 		]
 	},
-	"Riverpod: class": {
-        "scope": "dart",
+	"Riverpod codegen: Notifier / NotifierProvider": {
+		"scope": "dart",
 		"prefix": "riverpodClass",
-		"description": "Creates a class Provider",
+		"description": "Create a Notifier / NotifierProvider (codegen)",
 		"body": [
 			"@riverpod",
 			"class $1 extends _$$1 {",
 			"\t@override",
 			"\t$2 build() {",
-			"\t\treturn $3;",
+			"\t\t$3;",
 			"\t}",
 			"}",
 		]
 	},
-	"Riverpod: keep alive class": {
-        "scope": "dart",
+	"Riverpod codegen: Keep Alive Notifier / NotifierProvider": {
+		"scope": "dart",
 		"prefix": "riverpodClassKeepAlive",
-		"description": "Creates a keep alive class Provider",
+		"description": "Create a Keep Alive Notifier / NotifierProvider (codegen)",
 		"body": [
 			"@Riverpod(keepAlive: true)",
 			"class $1 extends _$$1 {",
 			"\t@override",
 			"\t$2 build() {",
-			"\t\treturn $3;",
+			"\t\t$3;",
 			"\t}",
 			"}",
 		]
 	},
-	"Riverpod: async class": {
-        "scope": "dart",
+	"Riverpod codegen: AsyncNotifier / AsyncNotifierProvider": {
+		"scope": "dart",
 		"prefix": "riverpodAsyncClass",
-		"description": "Creates an async class Provider",
+		"description": "Create an AsyncNotifier / AsyncNotifierProvider (codegen)",
 		"body": [
 			"@riverpod",
 			"class $1 extends _$$1 {",
 			"\t@override",
 			"\tFutureOr<$2> build() {",
-			"\t\treturn $3;",
+			"\t\t$3;",
 			"\t}",
 			"}",
 		]
 	},
-	"Riverpod: keep alive async class": {
-        "scope": "dart",
+	"Riverpod codegen: Keep Alive AsyncNotifier / AsyncNotifierProvider": {
+		"scope": "dart",
 		"prefix": "riverpodAsyncClassKeepAlive",
-		"description": "Creates a keep alive async class Provider",
+		"description": "Create a Keep Alive AsyncNotifier / AsyncNotifierProvider (codegen)",
 		"body": [
 			"@Riverpod(keepAlive: true)",
 			"class $1 extends _$$1 {",
 			"\t@override",
 			"\tFutureOr<$2> build() {",
-			"\t\treturn $3;",
+			"\t\t$3;",
 			"\t}",
 			"}",
 		]
 	},
-	"Riverpod: stream class": {
-        "scope": "dart",
+	"Riverpod codegen: StreamNotifier / StreamNotifierProvider": {
+		"scope": "dart",
 		"prefix": "riverpodStreamClass",
-		"description": "Creates an stream class Provider",
+		"description": "Create an StreamNotifier / StreamNotifierProvider (codegen)",
 		"body": [
 			"@riverpod",
 			"class $1 extends _$$1 {",
 			"\t@override",
 			"\tStream<$2> build() {",
-			"\t\treturn $3;",
+			"\t\t$3;",
 			"\t}",
 			"}",
 		]
 	},
-	"Riverpod: keep alive stream class": {
-        "scope": "dart",
+	"Riverpod codegen: Keep Alive StreamNotifier / StreamNotifierProvider": {
+		"scope": "dart",
 		"prefix": "riverpodStreamClassKeepAlive",
-		"description": "Creates a keep alive stream class Provider",
+		"description": "Create a Keep Alive StreamNotifier / StreamNotifierProvider (codegen)",
 		"body": [
 			"@Riverpod(keepAlive: true)",
 			"class $1 extends _$$1 {",
 			"\t@override",
 			"\tStream<$2> build() {",
-			"\t\treturn $3;",
+			"\t\t$3;",
 			"\t}",
 			"}",
 		]

--- a/snippets/code_generator.code-snippets
+++ b/snippets/code_generator.code-snippets
@@ -1,5 +1,5 @@
 {
-	"Riverpod codegen: part statement": {
+	"Riverpod (codegen): part statement": {
 		"scope": "dart",
 		"prefix": "riverpodPart",
 		"description": "Create a part statement for Riverpod (codegen)",
@@ -7,7 +7,7 @@
 			"part '${TM_FILENAME_BASE}.g.dart';",
 		]
 	},
-	"Riverpod codegen: Provider": {
+	"Riverpod (codegen): Provider": {
 		"scope": "dart",
 		"prefix": "riverpod",
 		"description": "Create a Provider (codegen)",
@@ -18,7 +18,7 @@
 			"}",
 		]
 	},
-	"Riverpod codegen: Keep Alive Provider": {
+	"Riverpod (codegen): Keep Alive Provider": {
 		"scope": "dart",
 		"prefix": "riverpodKeepAlive",
 		"description": "Create a non-autodispose Provider (codegen)",
@@ -29,7 +29,7 @@
 			"}",
 		]
 	},
-	"Riverpod codegen: FutureProvider": {
+	"Riverpod (codegen): FutureProvider": {
 		"scope": "dart",
 		"prefix": "riverpodFuture",
 		"description": "Create a FutureProvider (codegen)",
@@ -40,7 +40,7 @@
 			"}",
 		]
 	},
-	"Riverpod codegen: Keep Alive FutureProvider": {
+	"Riverpod (codegen): Keep Alive FutureProvider": {
 		"scope": "dart",
 		"prefix": "riverpodFutureKeepAlive",
 		"description": "Create a Keep Alive FutureProvider (codegen)",
@@ -51,7 +51,7 @@
 			"}",
 		]
 	},
-	"Riverpod codegen: StreamProvider": {
+	"Riverpod (codegen): StreamProvider": {
 		"scope": "dart",
 		"prefix": "riverpodStream",
 		"description": "Create a StreamProvider (codegen)",
@@ -62,7 +62,7 @@
 			"}",
 		]
 	},
-	"Riverpod codegen: Keep Alive StreamProvider": {
+	"Riverpod (codegen): Keep Alive StreamProvider": {
 		"scope": "dart",
 		"prefix": "riverpodStreamKeepAlive",
 		"description": "Create a Keep Alive StreamProvider (codegen)",
@@ -73,7 +73,7 @@
 			"}",
 		]
 	},
-	"Riverpod codegen: Notifier / NotifierProvider": {
+	"Riverpod (codegen): Notifier / NotifierProvider": {
 		"scope": "dart",
 		"prefix": "riverpodClass",
 		"description": "Create a Notifier / NotifierProvider (codegen)",
@@ -87,7 +87,7 @@
 			"}",
 		]
 	},
-	"Riverpod codegen: Keep Alive Notifier / NotifierProvider": {
+	"Riverpod (codegen): Keep Alive Notifier / NotifierProvider": {
 		"scope": "dart",
 		"prefix": "riverpodClassKeepAlive",
 		"description": "Create a Keep Alive Notifier / NotifierProvider (codegen)",
@@ -101,7 +101,7 @@
 			"}",
 		]
 	},
-	"Riverpod codegen: AsyncNotifier / AsyncNotifierProvider": {
+	"Riverpod (codegen): AsyncNotifier / AsyncNotifierProvider": {
 		"scope": "dart",
 		"prefix": "riverpodAsyncClass",
 		"description": "Create an AsyncNotifier / AsyncNotifierProvider (codegen)",
@@ -115,7 +115,7 @@
 			"}",
 		]
 	},
-	"Riverpod codegen: Keep Alive AsyncNotifier / AsyncNotifierProvider": {
+	"Riverpod (codegen): Keep Alive AsyncNotifier / AsyncNotifierProvider": {
 		"scope": "dart",
 		"prefix": "riverpodAsyncClassKeepAlive",
 		"description": "Create a Keep Alive AsyncNotifier / AsyncNotifierProvider (codegen)",
@@ -129,7 +129,7 @@
 			"}",
 		]
 	},
-	"Riverpod codegen: StreamNotifier / StreamNotifierProvider": {
+	"Riverpod (codegen): StreamNotifier / StreamNotifierProvider": {
 		"scope": "dart",
 		"prefix": "riverpodStreamClass",
 		"description": "Create an StreamNotifier / StreamNotifierProvider (codegen)",
@@ -143,7 +143,7 @@
 			"}",
 		]
 	},
-	"Riverpod codegen: Keep Alive StreamNotifier / StreamNotifierProvider": {
+	"Riverpod (codegen): Keep Alive StreamNotifier / StreamNotifierProvider": {
 		"scope": "dart",
 		"prefix": "riverpodStreamClassKeepAlive",
 		"description": "Create a Keep Alive StreamNotifier / StreamNotifierProvider (codegen)",

--- a/snippets/code_generator.code-snippets
+++ b/snippets/code_generator.code-snippets
@@ -2,7 +2,7 @@
 	"Riverpod (codegen): part statement": {
 		"scope": "dart",
 		"prefix": "riverpodPart",
-		"description": "Create a part statement for Riverpod (codegen)",
+		"description": "Creates a part statement for Riverpod (codegen)",
 		"body": [
 			"part '${TM_FILENAME_BASE}.g.dart';",
 		]
@@ -10,7 +10,7 @@
 	"Riverpod (codegen): Provider": {
 		"scope": "dart",
 		"prefix": "riverpod",
-		"description": "Create a Provider (codegen)",
+		"description": "Creates a Provider (codegen)",
 		"body": [
 			"@riverpod",
 			"$1 $2(Ref ref) {",
@@ -21,7 +21,7 @@
 	"Riverpod (codegen): Keep Alive Provider": {
 		"scope": "dart",
 		"prefix": "riverpodKeepAlive",
-		"description": "Create a non-autodispose Provider (codegen)",
+		"description": "Creates a non-autodispose Provider (codegen)",
 		"body": [
 			"@Riverpod(keepAlive: true)",
 			"$1 $2(Ref ref) {",
@@ -32,7 +32,7 @@
 	"Riverpod (codegen): FutureProvider": {
 		"scope": "dart",
 		"prefix": "riverpodFuture",
-		"description": "Create a FutureProvider (codegen)",
+		"description": "Creates a FutureProvider (codegen)",
 		"body": [
 			"@riverpod",
 			"FutureOr<$1> $2(Ref ref) {",
@@ -43,7 +43,7 @@
 	"Riverpod (codegen): Keep Alive FutureProvider": {
 		"scope": "dart",
 		"prefix": "riverpodFutureKeepAlive",
-		"description": "Create a Keep Alive FutureProvider (codegen)",
+		"description": "Creates a non-autodispose FutureProvider (codegen)",
 		"body": [
 			"@Riverpod(keepAlive: true)",
 			"FutureOr<$1> $2(Ref ref) {",
@@ -54,7 +54,7 @@
 	"Riverpod (codegen): StreamProvider": {
 		"scope": "dart",
 		"prefix": "riverpodStream",
-		"description": "Create a StreamProvider (codegen)",
+		"description": "Creates a StreamProvider (codegen)",
 		"body": [
 			"@riverpod",
 			"Stream<$1> $2(Ref ref) {",
@@ -65,7 +65,7 @@
 	"Riverpod (codegen): Keep Alive StreamProvider": {
 		"scope": "dart",
 		"prefix": "riverpodStreamKeepAlive",
-		"description": "Create a Keep Alive StreamProvider (codegen)",
+		"description": "Creates a non-autodispose StreamProvider (codegen)",
 		"body": [
 			"@Riverpod(keepAlive: true)",
 			"Stream<$1> $2(Ref ref) {",
@@ -76,7 +76,7 @@
 	"Riverpod (codegen): Notifier / NotifierProvider": {
 		"scope": "dart",
 		"prefix": "riverpodClass",
-		"description": "Create a Notifier / NotifierProvider (codegen)",
+		"description": "Creates an autodispose Notifier/NotifierProvider (codegen)",
 		"body": [
 			"@riverpod",
 			"class $1 extends _$$1 {",
@@ -90,7 +90,7 @@
 	"Riverpod (codegen): Keep Alive Notifier / NotifierProvider": {
 		"scope": "dart",
 		"prefix": "riverpodClassKeepAlive",
-		"description": "Create a Keep Alive Notifier / NotifierProvider (codegen)",
+		"description": "Creates a non-autodispose Notifier/NotifierProvider (codegen)",
 		"body": [
 			"@Riverpod(keepAlive: true)",
 			"class $1 extends _$$1 {",
@@ -104,7 +104,7 @@
 	"Riverpod (codegen): AsyncNotifier / AsyncNotifierProvider": {
 		"scope": "dart",
 		"prefix": "riverpodAsyncClass",
-		"description": "Create an AsyncNotifier / AsyncNotifierProvider (codegen)",
+		"description": "Creates an autodispose AsyncNotifier/AsyncNotifierProvider (codegen)",
 		"body": [
 			"@riverpod",
 			"class $1 extends _$$1 {",
@@ -118,7 +118,7 @@
 	"Riverpod (codegen): Keep Alive AsyncNotifier / AsyncNotifierProvider": {
 		"scope": "dart",
 		"prefix": "riverpodAsyncClassKeepAlive",
-		"description": "Create a Keep Alive AsyncNotifier / AsyncNotifierProvider (codegen)",
+		"description": "Creates a non-autodispose AsyncNotifier/AsyncNotifierProvider (codegen)",
 		"body": [
 			"@Riverpod(keepAlive: true)",
 			"class $1 extends _$$1 {",
@@ -132,7 +132,7 @@
 	"Riverpod (codegen): StreamNotifier / StreamNotifierProvider": {
 		"scope": "dart",
 		"prefix": "riverpodStreamClass",
-		"description": "Create an StreamNotifier / StreamNotifierProvider (codegen)",
+		"description": "Creates an autodispose StreamNotifier/StreamNotifierProvider (codegen)",
 		"body": [
 			"@riverpod",
 			"class $1 extends _$$1 {",
@@ -146,7 +146,7 @@
 	"Riverpod (codegen): Keep Alive StreamNotifier / StreamNotifierProvider": {
 		"scope": "dart",
 		"prefix": "riverpodStreamClassKeepAlive",
-		"description": "Create a Keep Alive StreamNotifier / StreamNotifierProvider (codegen)",
+		"description": "Creates a non-autodispose StreamNotifier/StreamNotifierProvider (codegen)",
 		"body": [
 			"@Riverpod(keepAlive: true)",
 			"class $1 extends _$$1 {",

--- a/snippets/consumer_widgets.code-snippets
+++ b/snippets/consumer_widgets.code-snippets
@@ -2,7 +2,7 @@
   "Consumer Stateless": {
     "scope": "dart",
     "prefix": "statelessConsumerWidget",
-    "description": "Create a ConsumerStatelessWidget",
+    "description": "Creates a ConsumerWidget",
     "body": [
       "class $1 extends ConsumerWidget {",
       "\tconst $1({super.key});\n",
@@ -16,7 +16,7 @@
   "Consumer Stateful": {
     "scope": "dart",
     "prefix": "statefulConsumerWidget",
-    "description": "Create a ConsumerStatefulWidget",
+    "description": "Creates a ConsumerStatefulWidget",
     "body": [
       "class $1 extends ConsumerStatefulWidget {",
       "\tconst $1({super.key});\n",

--- a/snippets/consumer_widgets.code-snippets
+++ b/snippets/consumer_widgets.code-snippets
@@ -1,7 +1,7 @@
 {
   "Consumer Stateless": {
     "scope": "dart",
-    "prefix": "stlessConsumer",
+    "prefix": "statelessConsumerWidget",
     "description": "Create a ConsumerStatelessWidget",
     "body": [
       "class $1 extends ConsumerWidget {",
@@ -15,7 +15,7 @@
   },
   "Consumer Stateful": {
     "scope": "dart",
-    "prefix": "stfulConsumer",
+    "prefix": "statefulConsumerWidget",
     "description": "Create a ConsumerStatefulWidget",
     "body": [
       "class $1 extends ConsumerStatefulWidget {",

--- a/snippets/future_provider.code-snippets
+++ b/snippets/future_provider.code-snippets
@@ -1,21 +1,31 @@
 {
-  "Future Provider": {
+  "Riverpod: Future Provider": {
     "scope": "dart",
     "prefix": "futureProvider",
-    "description": "Create a FutureProvider",
+    "description": "Create an autodispose FutureProvider",
     "body": [
-      "final $1Provider = FutureProvider<$2>((ref) async {",
-      "\treturn $3;",
+      "final $1Provider = FutureProvider.autoDispose<$2>((ref) async {",
+      "\t$3;",
       "});"
     ]
   },
-  "Future Provider with Family": {
+  "Riverpod: Keep Alive Future Provider": {
+    "scope": "dart",
+    "prefix": "futureProviderKeepAlive",
+    "description": "Create a non-autodispose FutureProvider",
+    "body": [
+      "final $1Provider = FutureProvider<$2>((ref) async {",
+      "\t$3;",
+      "});"
+    ]
+  },
+  "Riverpod: .family Future Provider": {
     "scope": "dart",
     "prefix": "futureProviderFamily",
-    "description": "Create a FutureProvider with Family",
+    "description": "Create an autodispose family FutureProvider",
     "body": [
-      "final $1Provider = FutureProvider.family<$2, $3>((ref, $4) async {",
-      "\treturn $5;",
+      "final $1Provider = FutureProvider.autoDispose.family<$2, $3>((ref, $4) async {",
+      "\t$5;",
       "});"
     ]
   }

--- a/snippets/future_provider.code-snippets
+++ b/snippets/future_provider.code-snippets
@@ -5,7 +5,7 @@
     "description": "Create an autodispose FutureProvider",
     "body": [
       "final $1Provider = FutureProvider.autoDispose<$2>((ref) async {",
-      "\t$3;",
+      "\t$3",
       "});"
     ]
   },
@@ -15,7 +15,7 @@
     "description": "Create a non-autodispose FutureProvider",
     "body": [
       "final $1Provider = FutureProvider<$2>((ref) async {",
-      "\t$3;",
+      "\t$3",
       "});"
     ]
   },
@@ -25,7 +25,7 @@
     "description": "Create an autodispose family FutureProvider",
     "body": [
       "final $1Provider = FutureProvider.autoDispose.family<$2, $3>((ref, $4) async {",
-      "\t$5;",
+      "\t$5",
       "});"
     ]
   }

--- a/snippets/future_provider.code-snippets
+++ b/snippets/future_provider.code-snippets
@@ -1,5 +1,5 @@
 {
-  "Riverpod: Future Provider": {
+  "Riverpod: FutureProvider": {
     "scope": "dart",
     "prefix": "futureProvider",
     "description": "Create an autodispose FutureProvider",
@@ -9,7 +9,7 @@
       "});"
     ]
   },
-  "Riverpod: Keep Alive Future Provider": {
+  "Riverpod: Keep Alive FutureProvider": {
     "scope": "dart",
     "prefix": "futureProviderKeepAlive",
     "description": "Create a non-autodispose FutureProvider",
@@ -19,7 +19,7 @@
       "});"
     ]
   },
-  "Riverpod: .family Future Provider": {
+  "Riverpod: .family FutureProvider": {
     "scope": "dart",
     "prefix": "futureProviderFamily",
     "description": "Create an autodispose family FutureProvider",

--- a/snippets/future_provider.code-snippets
+++ b/snippets/future_provider.code-snippets
@@ -2,7 +2,7 @@
   "Riverpod: FutureProvider": {
     "scope": "dart",
     "prefix": "futureProvider",
-    "description": "Create an autodispose FutureProvider",
+    "description": "Creates an autodispose FutureProvider",
     "body": [
       "final $1Provider = FutureProvider.autoDispose<$2>((ref) async {",
       "\t$3",
@@ -12,7 +12,7 @@
   "Riverpod: Keep Alive FutureProvider": {
     "scope": "dart",
     "prefix": "futureProviderKeepAlive",
-    "description": "Create a non-autodispose FutureProvider",
+    "description": "Creates a non-autodispose FutureProvider",
     "body": [
       "final $1Provider = FutureProvider<$2>((ref) async {",
       "\t$3",
@@ -22,7 +22,7 @@
   "Riverpod: .family FutureProvider": {
     "scope": "dart",
     "prefix": "futureProviderFamily",
-    "description": "Create an autodispose family FutureProvider",
+    "description": "Creates an autodispose family FutureProvider",
     "body": [
       "final $1Provider = FutureProvider.autoDispose.family<$2, $3>((ref, $4) async {",
       "\t$5",

--- a/snippets/hook_consumer.code-snippets
+++ b/snippets/hook_consumer.code-snippets
@@ -1,12 +1,11 @@
 {
   "Hook Consumer Stateless Widget": {
     "scope": "dart",
-    "prefix": "stlessHookConsumer",
+    "prefix": "statelessHookConsumerWidget",
     "description": "Create a HookConsumerWidget",
     "body": [
       "class $1 extends HookConsumerWidget {",
       "\tconst $1({super.key});",
-
       "\t@override",
       "\tWidget build(BuildContext context, WidgetRef ref) {",
       "\t\treturn Container();",
@@ -16,22 +15,20 @@
   },
   "Hook Consumer Stateful Widget": {
     "scope": "dart",
-    "prefix": "stfulHookConsumer",
+    "prefix": "statefulHookConsumerWidget",
     "description": "Create a StatefulHookConsumerWidget",
     "body": [
       "class $1 extends StatefulHookConsumerWidget {",
       "\tconst $1({super.key});\n",
-		  "\t@override",
-		  "\tConsumerState<ConsumerStatefulWidget> createState() => _$1State();",
-		  "}",
-	
-		  "class _$1State extends ConsumerState<$1> {",
-	
-		  "\t@override",
-		  "\tWidget build(BuildContext context) {",
-		  "\t\treturn Container();",
-		  "\t}",
-		  "}"
+      "\t@override",
+      "\tConsumerState<ConsumerStatefulWidget> createState() => _$1State();",
+      "}",
+      "class _$1State extends ConsumerState<$1> {",
+      "\t@override",
+      "\tWidget build(BuildContext context) {",
+      "\t\treturn Container();",
+      "\t}",
+      "}"
     ]
   }
 }

--- a/snippets/hook_consumer.code-snippets
+++ b/snippets/hook_consumer.code-snippets
@@ -2,7 +2,7 @@
   "Hook Consumer Stateless Widget": {
     "scope": "dart",
     "prefix": "statelessHookConsumerWidget",
-    "description": "Create a HookConsumerWidget",
+    "description": "Creates a HookConsumerWidget",
     "body": [
       "class $1 extends HookConsumerWidget {",
       "\tconst $1({super.key});",
@@ -16,7 +16,7 @@
   "Hook Consumer Stateful Widget": {
     "scope": "dart",
     "prefix": "statefulHookConsumerWidget",
-    "description": "Create a StatefulHookConsumerWidget",
+    "description": "Creates a StatefulHookConsumerWidget",
     "body": [
       "class $1 extends StatefulHookConsumerWidget {",
       "\tconst $1({super.key});\n",

--- a/snippets/notifier.code-snippets
+++ b/snippets/notifier.code-snippets
@@ -1,8 +1,8 @@
 {
-	"Riverpod: Notifier class": {
+	"Riverpod: Notifier": {
 		"scope": "dart",
 		"prefix": "notifier",
-		"description": "Create a Notifier class",
+		"description": "Creates a Notifier",
 		"body": [
 			"class $1Notifier extends Notifier<$2> {",
 			"\t@override",
@@ -12,10 +12,10 @@
 			"}"
 		]
 	},
-	"Riverpod: Family Notifier class": {
+	"Riverpod: Family Notifier": {
 		"scope": "dart",
 		"prefix": "notifierFamily",
-		"description": "Create a parametrized Notifier",
+		"description": "Creates a parametrized Notifier",
 		"body": [
 			"class $1Notifier extends Notifier<$2> {",
 			"\t$1Notifier(this.$4);",

--- a/snippets/notifier.code-snippets
+++ b/snippets/notifier.code-snippets
@@ -1,26 +1,28 @@
 {
-    "Riverpod: Notifier class": {
-        "scope": "dart",
+	"Riverpod: Notifier class": {
+		"scope": "dart",
 		"prefix": "notifier",
 		"description": "Create a Notifier class",
 		"body": [
 			"class $1Notifier extends Notifier<$2> {",
 			"\t@override",
 			"\t$2 build() {",
-			"\t\treturn $3;",
+			"\t\t$3",
 			"\t}",
 			"}"
 		]
 	},
 	"Riverpod: Family Notifier class": {
-        "scope": "dart",
+		"scope": "dart",
 		"prefix": "notifierFamily",
-		"description": "Create a Notifier with Editable Parameter",
+		"description": "Create a parametrized Notifier",
 		"body": [
-			"class $1Notifier extends FamilyNotifier<$2, $3> {",
+			"class $1Notifier extends Notifier<$2> {",
+			"\t$1Notifier(this.$4);",
+			"\tfinal $3 $4;",
 			"\t@override",
-			"\t$2 build($3 arg) {",
-			"\t\treturn $4;",
+			"\t$2 build() {",
+			"\t\t$5",
 			"\t}",
 			"}"
 		]

--- a/snippets/notifier_provider.code-snippets
+++ b/snippets/notifier_provider.code-snippets
@@ -1,18 +1,26 @@
 {
-    "Riverpod: Notifier Provider": {
-        "scope": "dart",
+	"Riverpod: NotifierProvider": {
+		"scope": "dart",
 		"prefix": "notifierProvider",
-		"description": "Create a NotifierProvider",
+		"description": "Create an autodispose NotifierProvider",
+		"body": [
+			"final $1Provider = NotifierProvider.autoDispose<$2, $3>($2.new);",
+		]
+	},
+	"Riverpod: Keep Alive NotifierProvider": {
+		"scope": "dart",
+		"prefix": "notifierProviderKeepAlive",
+		"description": "Create a non-autodispose NotifierProvider",
 		"body": [
 			"final $1Provider = NotifierProvider<$2, $3>($2.new);",
 		]
 	},
-	"Riverpod: Notifier Provider with Family": {
-        "scope": "dart",
+	"Riverpod: .family NotifierProvider": {
+		"scope": "dart",
 		"prefix": "notifierProviderFamily",
-		"description": "Create a NotifierProvider with Family Modifier",
+		"description": "Create an autodispose family NotifierProvider",
 		"body": [
-			"final $1Provider = NotifierProviderFamily<$2, $3, $4>($2.new);",
+			"final $1Provider = NotifierProvider.autoDispose.family<$2, $3, $4>($2.new);",
 		]
 	},
 }

--- a/snippets/notifier_provider.code-snippets
+++ b/snippets/notifier_provider.code-snippets
@@ -2,7 +2,7 @@
 	"Riverpod: NotifierProvider": {
 		"scope": "dart",
 		"prefix": "notifierProvider",
-		"description": "Create an autodispose NotifierProvider",
+		"description": "Creates an autodispose NotifierProvider",
 		"body": [
 			"final $1Provider = NotifierProvider.autoDispose<$2, $3>($2.new);",
 		]
@@ -10,7 +10,7 @@
 	"Riverpod: Keep Alive NotifierProvider": {
 		"scope": "dart",
 		"prefix": "notifierProviderKeepAlive",
-		"description": "Create a non-autodispose NotifierProvider",
+		"description": "Creates a non-autodispose NotifierProvider",
 		"body": [
 			"final $1Provider = NotifierProvider<$2, $3>($2.new);",
 		]
@@ -18,7 +18,7 @@
 	"Riverpod: .family NotifierProvider": {
 		"scope": "dart",
 		"prefix": "notifierProviderFamily",
-		"description": "Create an autodispose family NotifierProvider",
+		"description": "Creates an autodispose family NotifierProvider",
 		"body": [
 			"final $1Provider = NotifierProvider.autoDispose.family<$2, $3, $4>($2.new);",
 		]

--- a/snippets/provider.code-snippets
+++ b/snippets/provider.code-snippets
@@ -1,21 +1,31 @@
 {
-  "Provider": {
+  "Riverpod: Provider": {
     "scope": "dart",
     "prefix": "provider",
-    "description": "Create a simple Provider",
+    "description": "Create an autodispose Provider",
     "body": [
-      "final $1Provider = Provider<$2>((ref) {",
-      "\treturn $3;",
+      "final $1Provider = Provider.autoDispose<$2>((ref) {",
+      "\t$3",
       "});",
     ]
   },
-  "Provider with Family": {
+  "Riverpod: Keep Alive Provider": {
+    "scope": "dart",
+    "prefix": "provider",
+    "description": "Create a non-autodispose Provider",
+    "body": [
+      "final $1Provider = Provider<$2>((ref) {",
+      "\t$3",
+      "});",
+    ]
+  },
+  "Riverpod: .family Provider": {
     "scope": "dart",
     "prefix": "providerFamily",
-    "description": "Create a simple Provider with Family modifier",
+    "description": "Create an autodispose family Provider",
     "body": [
-      "final $1Provider = Provider.family<$2, $3>((ref, $4) {",
-      "\treturn $5;",
+      "final $1Provider = Provider.autoDispose.family<$2, $3>((ref, $4) {",
+      "\t$5",
       "});"
     ]
   }

--- a/snippets/provider.code-snippets
+++ b/snippets/provider.code-snippets
@@ -2,7 +2,7 @@
   "Riverpod: Provider": {
     "scope": "dart",
     "prefix": "provider",
-    "description": "Create an autodispose Provider",
+    "description": "Creates an autodispose Provider",
     "body": [
       "final $1Provider = Provider.autoDispose<$2>((ref) {",
       "\t$3",
@@ -12,7 +12,7 @@
   "Riverpod: Keep Alive Provider": {
     "scope": "dart",
     "prefix": "provider",
-    "description": "Create a non-autodispose Provider",
+    "description": "Creates a non-autodispose Provider",
     "body": [
       "final $1Provider = Provider<$2>((ref) {",
       "\t$3",
@@ -22,7 +22,7 @@
   "Riverpod: .family Provider": {
     "scope": "dart",
     "prefix": "providerFamily",
-    "description": "Create an autodispose family Provider",
+    "description": "Creates an autodispose family Provider",
     "body": [
       "final $1Provider = Provider.autoDispose.family<$2, $3>((ref, $4) {",
       "\t$5",

--- a/snippets/provider_listenable.code-snippets
+++ b/snippets/provider_listenable.code-snippets
@@ -1,8 +1,8 @@
 {
-  "Provider Listenable": {
+  "Riverpod: Listener": {
     "scope": "dart",
     "prefix": "listen",
-    "description": "Create a provider listenable",
+    "description": "Listen to a provider",
     "body": [
       "ref.listen<$1>($2, (previous, next) { ",
       "\t$3",

--- a/snippets/state_notifier.code-snippets
+++ b/snippets/state_notifier.code-snippets
@@ -1,12 +1,24 @@
 {
-  "State Notifier": {
+  "Legacy: State Notifier": {
     "scope": "dart",
     "prefix": "stateNotifier",
-    "description": "Create a StateNotifier with Editable Parameter",
+    "description": "Create a StateNotifier",
     "body": [
       "class $1Notifier extends StateNotifier<$2> {",
       "\t$1Notifier(): super($3);",
       "\t$4",
+      "}"
+    ]
+  },
+  "Legacy: .family State Notifier": {
+    "scope": "dart",
+    "prefix": "stateNotifierFamily",
+    "description": "Create a .family StateNotifier",
+    "body": [
+      "class $1Notifier extends StateNotifier<$2> {",
+      "\t$1Notifier(this.$5): super($3);",
+      "\tfinal $4 $5;",
+      "\t$6",
       "}"
     ]
   }

--- a/snippets/state_notifier.code-snippets
+++ b/snippets/state_notifier.code-snippets
@@ -2,7 +2,7 @@
   "Riverpod (legacy): State Notifier": {
     "scope": "dart",
     "prefix": "stateNotifier",
-    "description": "Create a StateNotifier",
+    "description": "Creates a StateNotifier",
     "body": [
       "class $1Notifier extends StateNotifier<$2> {",
       "\t$1Notifier(): super($3);",
@@ -13,7 +13,7 @@
   "Riverpod (legacy): .family State Notifier": {
     "scope": "dart",
     "prefix": "stateNotifierFamily",
-    "description": "Create a .family StateNotifier",
+    "description": "Creates a parametrized StateNotifier",
     "body": [
       "class $1Notifier extends StateNotifier<$2> {",
       "\t$1Notifier(this.$5): super($3);",

--- a/snippets/state_notifier.code-snippets
+++ b/snippets/state_notifier.code-snippets
@@ -1,5 +1,5 @@
 {
-  "Legacy: State Notifier": {
+  "Riverpod (legacy): State Notifier": {
     "scope": "dart",
     "prefix": "stateNotifier",
     "description": "Create a StateNotifier",
@@ -10,7 +10,7 @@
       "}"
     ]
   },
-  "Legacy: .family State Notifier": {
+  "Riverpod (legacy): .family State Notifier": {
     "scope": "dart",
     "prefix": "stateNotifierFamily",
     "description": "Create a .family StateNotifier",

--- a/snippets/state_notifier_provider.code-snippets
+++ b/snippets/state_notifier_provider.code-snippets
@@ -2,7 +2,7 @@
   "Riverpod (legacy): StateNotifier Provider": {
     "scope": "dart",
     "prefix": "stateNotifierProvider",
-    "description": "Create an autodispose StateNotifierProvider",
+    "description": "Creates an autodispose StateNotifierProvider",
     "body": [
       "final $1Provider = StateNotifierProvider.autoDispose<$2, $3>((ref) {",
       "\treturn $2();",
@@ -12,7 +12,7 @@
   "Riverpod (legacy): Keep Alive StateNotifier Provider": {
     "scope": "dart",
     "prefix": "stateNotifierProviderKeepAlive",
-    "description": "Create a non-autodispose StateNotifierProvider",
+    "description": "Creates a non-autodispose StateNotifierProvider",
     "body": [
       "final $1Provider = StateNotifierProvider<$2, $3>((ref) {",
       "\treturn $2();",
@@ -22,7 +22,7 @@
   "Riverpod (legacy): .family StateNotifier Provider": {
     "scope": "dart",
     "prefix": "stateNotifierProviderFamily",
-    "description": "Create an autodispose family StateNotifierProvider",
+    "description": "Creates an autodispose family StateNotifierProvider",
     "body": [
       "final $1Provider = StateNotifierProvider.autoDispose.family<$2, $3, $4>((ref, $5) {",
       "\treturn $2($5);",

--- a/snippets/state_notifier_provider.code-snippets
+++ b/snippets/state_notifier_provider.code-snippets
@@ -1,5 +1,5 @@
 {
-  "Legacy: StateNotifier Provider": {
+  "Riverpod (legacy): StateNotifier Provider": {
     "scope": "dart",
     "prefix": "stateNotifierProvider",
     "description": "Create an autodispose StateNotifierProvider",
@@ -9,7 +9,7 @@
       "});"
     ]
   },
-  "Legacy: Keep Alive StateNotifier Provider": {
+  "Riverpod (legacy): Keep Alive StateNotifier Provider": {
     "scope": "dart",
     "prefix": "stateNotifierProviderKeepAlive",
     "description": "Create a non-autodispose StateNotifierProvider",
@@ -19,7 +19,7 @@
       "});"
     ]
   },
-  "Legacy: .family StateNotifier Provider": {
+  "Riverpod (legacy): .family StateNotifier Provider": {
     "scope": "dart",
     "prefix": "stateNotifierProviderFamily",
     "description": "Create an autodispose family StateNotifierProvider",

--- a/snippets/state_notifier_provider.code-snippets
+++ b/snippets/state_notifier_provider.code-snippets
@@ -1,21 +1,31 @@
 {
-  "State Notifier Provider": {
+  "Legacy: StateNotifier Provider": {
     "scope": "dart",
     "prefix": "stateNotifierProvider",
-    "description": "Create a StateNotifierProvider",
+    "description": "Create an autodispose StateNotifierProvider",
     "body": [
-      "final $1Provider = StateNotifierProvider<$2>((ref) {",
-      "\treturn $3",
+      "final $1Provider = StateNotifierProvider.autoDispose<$2, $3>((ref) {",
+      "\treturn $2();",
       "});"
     ]
   },
-  "State Notifier Provider with Family": {
+  "Legacy: Always-Alive StateNotifier Provider": {
+    "scope": "dart",
+    "prefix": "alwaysAliveStateNotifierProvider",
+    "description": "Create a non-autodispose StateNotifierProvider",
+    "body": [
+      "final $1Provider = StateNotifierProvider<$2, $3>((ref) {",
+      "\treturn $2();",
+      "});"
+    ]
+  },
+  "Legacy: .family StateNotifier Provider": {
     "scope": "dart",
     "prefix": "stateNotifierProviderFamily",
-    "description": "Create a StateNotifierProvider with Family Modifier",
+    "description": "Create an autodispose family StateNotifierProvider",
     "body": [
-      "final $1Provider = StateNotifierProvider.family<$2, $3>((ref, $4) {",
-      "\treturn $5",
+      "final $1Provider = StateNotifierProvider.autoDispose.family<$2, $3, $4>((ref, $5) {",
+      "\treturn $2($5);",
       "});"
     ]
   }

--- a/snippets/state_notifier_provider.code-snippets
+++ b/snippets/state_notifier_provider.code-snippets
@@ -9,9 +9,9 @@
       "});"
     ]
   },
-  "Legacy: Always-Alive StateNotifier Provider": {
+  "Legacy: Keep Alive StateNotifier Provider": {
     "scope": "dart",
-    "prefix": "alwaysAliveStateNotifierProvider",
+    "prefix": "stateNotifierProviderKeepAlive",
     "description": "Create a non-autodispose StateNotifierProvider",
     "body": [
       "final $1Provider = StateNotifierProvider<$2, $3>((ref) {",

--- a/snippets/state_provider.code-snippets
+++ b/snippets/state_provider.code-snippets
@@ -1,21 +1,31 @@
 {
-  "State Provider": {
+  "Legacy: State Provider": {
     "scope": "dart",
     "prefix": "stateProvider",
-    "description": "Create a StateProvider",
+    "description": "Create an autodispose StateProvider",
     "body": [
-      "final $1Provider = StateProvider<$2>((ref) {",
-      "\treturn $3;",
+      "final $1Provider = StateProvider.autoDispose<$2>((ref) {",
+      "\t$3",
       "});",
     ]
   },
-  "State Provider Family": {
+  "Legacy: Keep Alive State Provider": {
+    "scope": "dart",
+    "prefix": "stateProvider",
+    "description": "Create a non-autodispose StateProvider",
+    "body": [
+      "final $1Provider = StateProvider<$2>((ref) {",
+      "\t$3",
+      "});",
+    ]
+  },
+  "Legacy: State Provider Family": {
     "scope": "dart",
     "prefix": "stateProviderFamily",
-    "description": "Create a StateProvider with Family modifier",
+    "description": "Create an autodispose family StateProvider",
     "body": [
-      "final $1Provider = StateProvider.family<$2, $3>((ref, $4) {",
-      "\treturn $5;",
+      "final $1Provider = StateProvider.autoDispose.family<$2, $3>((ref, $4) {",
+      "\t$5",
       "});"
     ]
   }

--- a/snippets/state_provider.code-snippets
+++ b/snippets/state_provider.code-snippets
@@ -1,5 +1,5 @@
 {
-  "Legacy: State Provider": {
+  "Riverpod (legacy): State Provider": {
     "scope": "dart",
     "prefix": "stateProvider",
     "description": "Create an autodispose StateProvider",
@@ -9,7 +9,7 @@
       "});",
     ]
   },
-  "Legacy: Keep Alive State Provider": {
+  "Riverpod (legacy): Keep Alive State Provider": {
     "scope": "dart",
     "prefix": "stateProvider",
     "description": "Create a non-autodispose StateProvider",
@@ -19,7 +19,7 @@
       "});",
     ]
   },
-  "Legacy: State Provider Family": {
+  "Riverpod (legacy): State Provider Family": {
     "scope": "dart",
     "prefix": "stateProviderFamily",
     "description": "Create an autodispose family StateProvider",

--- a/snippets/state_provider.code-snippets
+++ b/snippets/state_provider.code-snippets
@@ -2,7 +2,7 @@
   "Riverpod (legacy): State Provider": {
     "scope": "dart",
     "prefix": "stateProvider",
-    "description": "Create an autodispose StateProvider",
+    "description": "Creates an autodispose StateProvider",
     "body": [
       "final $1Provider = StateProvider.autoDispose<$2>((ref) {",
       "\t$3",
@@ -11,8 +11,8 @@
   },
   "Riverpod (legacy): Keep Alive State Provider": {
     "scope": "dart",
-    "prefix": "stateProvider",
-    "description": "Create a non-autodispose StateProvider",
+    "prefix": "stateProviderKeepAlive",
+    "description": "Creates a non-autodispose StateProvider",
     "body": [
       "final $1Provider = StateProvider<$2>((ref) {",
       "\t$3",
@@ -22,7 +22,7 @@
   "Riverpod (legacy): State Provider Family": {
     "scope": "dart",
     "prefix": "stateProviderFamily",
-    "description": "Create an autodispose family StateProvider",
+    "description": "Creates an autodispose family StateProvider",
     "body": [
       "final $1Provider = StateProvider.autoDispose.family<$2, $3>((ref, $4) {",
       "\t$5",

--- a/snippets/stream_notifier.code-snippets
+++ b/snippets/stream_notifier.code-snippets
@@ -1,26 +1,28 @@
 {
-    "Riverpod: StreamNotifier class": {
-        "scope": "dart",
+	"Riverpod: StreamNotifier class": {
+		"scope": "dart",
 		"prefix": "streamNotifier",
-		"description": "Create an StreamNotifier class",
+		"description": "Create a StreamNotifier class",
 		"body": [
 			"class $1Notifier extends StreamNotifier<$2> {",
 			"\t@override",
 			"\tStream<$2> build() {",
-			"\t\treturn $3;",
+			"\t\t$3",
 			"\t}",
 			"}"
 		]
 	},
 	"Riverpod: Family StreamNotifier class": {
-        "scope": "dart",
+		"scope": "dart",
 		"prefix": "streamNotifierFamily",
-		"description": "Create an StreamNotifier with Family Parameter",
+		"description": "Create a parametrized StreamNotifier",
 		"body": [
-			"class $1Notifier extends FamilyStreamNotifier<$2, $3> {",
+			"class $1Notifier extends StreamNotifier<$2> {",
+			"\t$1Notifier(this.$4);",
+			"\tfinal $3 $4;",
 			"\t@override",
-			"\tStream<$2> build($3 arg) {",
-			"\t\treturn $4;",
+			"\tStream<$2> build() {",
+			"\t\t$5",
 			"\t}",
 			"}"
 		]

--- a/snippets/stream_notifier.code-snippets
+++ b/snippets/stream_notifier.code-snippets
@@ -1,8 +1,8 @@
 {
-	"Riverpod: StreamNotifier class": {
+	"Riverpod: StreamNotifier": {
 		"scope": "dart",
 		"prefix": "streamNotifier",
-		"description": "Create a StreamNotifier class",
+		"description": "Creates a StreamNotifier",
 		"body": [
 			"class $1Notifier extends StreamNotifier<$2> {",
 			"\t@override",
@@ -12,10 +12,10 @@
 			"}"
 		]
 	},
-	"Riverpod: Family StreamNotifier class": {
+	"Riverpod: Family StreamNotifier": {
 		"scope": "dart",
 		"prefix": "streamNotifierFamily",
-		"description": "Create a parametrized StreamNotifier",
+		"description": "Creates a parametrized StreamNotifier",
 		"body": [
 			"class $1Notifier extends StreamNotifier<$2> {",
 			"\t$1Notifier(this.$4);",

--- a/snippets/stream_notifier_provider.code-snippets
+++ b/snippets/stream_notifier_provider.code-snippets
@@ -1,18 +1,26 @@
 {
-    "Riverpod: StreamNotifier Provider": {
-        "scope": "dart",
+	"Riverpod: StreamNotifierProvider": {
+		"scope": "dart",
 		"prefix": "streamNotifierProvider",
-		"description": "Create an StreamNotifierProvider",
+		"description": "Create an autodispose StreamNotifierProvider",
+		"body": [
+			"final $1Provider = StreamNotifierProvider.autoDispose<$2, $3>($2.new);",
+		]
+	},
+	"Riverpod: Keep Alive StreamNotifierProvider": {
+		"scope": "dart",
+		"prefix": "streamNotifierProviderKeepAlive",
+		"description": "Create a non-autodispose StreamNotifierProvider",
 		"body": [
 			"final $1Provider = StreamNotifierProvider<$2, $3>($2.new);",
 		]
 	},
-	"Riverpod: StreamNotifier Provider with Family": {
-        "scope": "dart",
+	"Riverpod: .family StreamNotifierProvider": {
+		"scope": "dart",
 		"prefix": "streamNotifierProviderFamily",
-		"description": "Create an StreamNotifierProvider with Family Modifier",
+		"description": "Create an autodispose family StreamNotifierProvider",
 		"body": [
-			"final $1Provider = StreamNotifierProviderFamily<$2, $3, $4>($2.new);",
+			"final $1Provider = StreamNotifierProvider.autoDispose.family<$2, $3, $4>($2.new);",
 		]
 	},
 }

--- a/snippets/stream_notifier_provider.code-snippets
+++ b/snippets/stream_notifier_provider.code-snippets
@@ -2,7 +2,7 @@
 	"Riverpod: StreamNotifierProvider": {
 		"scope": "dart",
 		"prefix": "streamNotifierProvider",
-		"description": "Create an autodispose StreamNotifierProvider",
+		"description": "Creates an autodispose StreamNotifierProvider",
 		"body": [
 			"final $1Provider = StreamNotifierProvider.autoDispose<$2, $3>($2.new);",
 		]
@@ -10,7 +10,7 @@
 	"Riverpod: Keep Alive StreamNotifierProvider": {
 		"scope": "dart",
 		"prefix": "streamNotifierProviderKeepAlive",
-		"description": "Create a non-autodispose StreamNotifierProvider",
+		"description": "Creates a non-autodispose StreamNotifierProvider",
 		"body": [
 			"final $1Provider = StreamNotifierProvider<$2, $3>($2.new);",
 		]
@@ -18,7 +18,7 @@
 	"Riverpod: .family StreamNotifierProvider": {
 		"scope": "dart",
 		"prefix": "streamNotifierProviderFamily",
-		"description": "Create an autodispose family StreamNotifierProvider",
+		"description": "Creates an autodispose family StreamNotifierProvider",
 		"body": [
 			"final $1Provider = StreamNotifierProvider.autoDispose.family<$2, $3, $4>($2.new);",
 		]

--- a/snippets/stream_provider.code-snippets
+++ b/snippets/stream_provider.code-snippets
@@ -2,7 +2,7 @@
   "Riverpod: StreamProvider": {
     "scope": "dart",
     "prefix": "streamProvider",
-    "description": "Create an autodispose StreamProvider",
+    "description": "Creates an autodispose StreamProvider",
     "body": [
       "final $1Provider = StreamProvider.autoDispose<$2>((ref) {",
       "\t$3",
@@ -12,7 +12,7 @@
   "Riverpod: Keep Alive StreamProvider": {
     "scope": "dart",
     "prefix": "streamProviderKeepAlive",
-    "description": "Create a non-autodispose StreamProvider",
+    "description": "Creates a non-autodispose StreamProvider",
     "body": [
       "final $1Provider = StreamProvider<$2>((ref) {",
       "\t$3",
@@ -22,7 +22,7 @@
   "Riverpod: .family StreamProvider": {
     "scope": "dart",
     "prefix": "streamProviderFamily",
-    "description": "Create an autodispose family StreamProvider",
+    "description": "Creates an autodispose family StreamProvider",
     "body": [
       "final $1Provider = StreamProvider.autoDispose.family<$2, $3>((ref, $4) {",
       "\t$5",

--- a/snippets/stream_provider.code-snippets
+++ b/snippets/stream_provider.code-snippets
@@ -1,21 +1,31 @@
 {
-  "State Provider": {
+  "Riverpod: StreamProvider": {
     "scope": "dart",
     "prefix": "streamProvider",
-    "description": "Create a StreamProvider",
+    "description": "Create an autodispose StreamProvider",
     "body": [
-      "final $1Provider = StreamProvider<$2>((ref) async* {",
-      "\treturn $3;",
+      "final $1Provider = StreamProvider.autoDispose<$2>((ref) {",
+      "\t$3",
       "});"
     ]
   },
-  "State Provider Family": {
+  "Riverpod: Keep Alive StreamProvider": {
+    "scope": "dart",
+    "prefix": "streamProviderKeepAlive",
+    "description": "Create a non-autodispose StreamProvider",
+    "body": [
+      "final $1Provider = StreamProvider<$2>((ref) {",
+      "\t$3",
+      "});"
+    ]
+  },
+  "Riverpod: .family StreamProvider": {
     "scope": "dart",
     "prefix": "streamProviderFamily",
-    "description": "Create a StreamProvider with Family modifier",
+    "description": "Create an autodispose family StreamProvider",
     "body": [
-      "final $1Provider = StreamProvider.family<$2, $3>((ref, $4) async* {",
-      "\treturn $5;",
+      "final $1Provider = StreamProvider.autoDispose.family<$2, $3>((ref, $4) {",
+      "\t$5",
       "});"
     ]
   }


### PR DESCRIPTION
fixes #38, aka these snippets are now compatible with riverpod 3.0, but also:
- corrected some incorrect naming
- better snippet consistency
- better snippet flexibility (removed some quite avoidable `return` statements)
- improved "keep alive" snippets (aka non-autodispose providers)
- `.autoDispose` is offered as default behaviour, opt-in to always alive by appending `KeepAlive` to snippets
- `.family` now MUST come with `.autoDispose` modifier (as per [docs](https://riverpod.dev/docs/concepts2/family))
- appended "legacy" to better describe `ChaneNotifier` and `StateNotifier` snippets
- `streamProvider`: removed `async*`